### PR TITLE
Add detailed Wikipedia build progress logs

### DIFF
--- a/scripts/build-data.ts
+++ b/scripts/build-data.ts
@@ -1,20 +1,45 @@
 import { readFile, writeFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
-import { buildRecordsData, parseSourcesFile } from './wikipedia-records.ts';
+import { type BuildProgress, buildRecordsData, parseSourcesFile } from './wikipedia-records.ts';
 
 const sourcePath = resolve('urls.txt');
 const outputPath = resolve('src/data/results.json');
 
 async function main(): Promise<void> {
+  console.log(`Reading Wikipedia page list from ${sourcePath}`);
   const sources = parseSourcesFile(await readFile(sourcePath, 'utf8'));
-  process.stdout.write(`Refreshing records from ${sources.length} Wikipedia pages`);
+  console.log(`Found ${sources.length} Wikipedia pages to refresh.`);
 
-  const data = await buildRecordsData(sources, fetch, (completed, total) => {
-    if (completed % 10 === 0 || completed === total) process.stdout.write('.');
-  });
+  const data = await buildRecordsData(sources, fetch, logProgress);
 
+  console.log(`Finished processing ${data.sourcePageCount} Wikipedia pages.`);
+  console.log(`Writing generated records to ${outputPath}`);
   await writeFile(outputPath, `${JSON.stringify(data, null, 2)}\n`, 'utf8');
-  process.stdout.write(`\nWrote ${outputPath}\n`);
+  console.log(`Wrote ${outputPath}`);
+}
+
+function logProgress(progress: BuildProgress): void {
+  if (progress.stage === 'retrying') {
+    console.warn(
+      `Retrying ${progress.source.country} (attempt ${progress.attempt}/${progress.maxAttempts}) ` +
+        `in ${formatDelay(progress.delayMilliseconds)}: ${progress.reason}`,
+    );
+    return;
+  }
+
+  const prefix = `[${progress.pageNumber}/${progress.totalPages}]`;
+  if (progress.stage === 'fetching') {
+    const url = new URL(progress.source.url, 'https://en.wikipedia.org');
+    console.log(`${prefix} Fetching ${progress.source.country}: ${url.href}`);
+  } else {
+    console.log(
+      `${prefix} Processed ${progress.source.country}: found ${progress.recordCount} supported records.`,
+    );
+  }
+}
+
+function formatDelay(milliseconds: number): string {
+  return milliseconds < 1_000 ? `${milliseconds}ms` : `${milliseconds / 1_000}s`;
 }
 
 await main();

--- a/scripts/wikipedia-records.ts
+++ b/scripts/wikipedia-records.ts
@@ -15,6 +15,31 @@ export interface WikipediaSource {
 
 type Fetcher = typeof fetch;
 
+export type BuildProgress =
+  | {
+      stage: 'fetching';
+      source: WikipediaSource;
+      pageNumber: number;
+      totalPages: number;
+    }
+  | {
+      stage: 'retrying';
+      source: WikipediaSource;
+      attempt: number;
+      maxAttempts: number;
+      delayMilliseconds: number;
+      reason: string;
+    }
+  | {
+      stage: 'processed';
+      source: WikipediaSource;
+      pageNumber: number;
+      totalPages: number;
+      recordCount: number;
+    };
+
+type ProgressReporter = (progress: BuildProgress) => void;
+
 const WIKIPEDIA_ORIGIN = 'https://en.wikipedia.org';
 const EVENT_TITLES = new Map<string, EventName>(EVENTS.map((event) => [event, event]));
 const REQUEST_TIMEOUT_MS = 25_000;
@@ -169,29 +194,43 @@ export function parseWikipediaRecords(
 export async function buildRecordsData(
   sources: WikipediaSource[],
   fetcher: Fetcher = fetch,
-  onProgress: (completed: number, total: number) => void = () => {},
+  onProgress: ProgressReporter = () => {},
 ): Promise<RecordsData> {
   const events = createEmptyEvents();
   let completed = 0;
   const waitForRequestSlot = createRequestPacer(MIN_REQUEST_INTERVAL_MS);
 
   await mapWithConcurrency(sources, MAX_CONCURRENCY, async (source) => {
+    const pageNumber = completed + 1;
+    onProgress({ stage: 'fetching', source, pageNumber, totalPages: sources.length });
+
     try {
-      const html = await fetchWikipediaPage(source, fetcher, waitForRequestSlot);
+      const html = await fetchWikipediaPage(source, fetcher, waitForRequestSlot, onProgress);
       const parsed = parseWikipediaRecords(html, source);
+      let recordCount = 0;
 
       for (const gender of GENDERS) {
         for (const event of EVENTS) {
           const record = parsed[gender]?.[event];
-          if (record) events[event][gender].push(record);
+          if (record) {
+            events[event][gender].push(record);
+            recordCount += 1;
+          }
         }
       }
+
+      onProgress({
+        stage: 'processed',
+        source,
+        pageNumber,
+        totalPages: sources.length,
+        recordCount,
+      });
     } catch (error) {
       const reason = error instanceof Error ? error.message : String(error);
       throw new Error(`Failed to load records for ${source.country}: ${reason}`, { cause: error });
     } finally {
       completed += 1;
-      onProgress(completed, sources.length);
     }
   });
 
@@ -212,6 +251,7 @@ export async function fetchWikipediaPage(
   source: WikipediaSource,
   fetcher: Fetcher,
   waitForRequestSlot: () => Promise<void> = () => Promise.resolve(),
+  onProgress: ProgressReporter = () => {},
 ): Promise<string> {
   const url = new URL(source.url, WIKIPEDIA_ORIGIN);
   let lastError: unknown;
@@ -236,14 +276,20 @@ export async function fetchWikipediaPage(
         if (attempt === MAX_FETCH_ATTEMPTS) throw error;
 
         lastError = error;
-        await wait(getRetryDelay(response.headers.get('retry-after'), attempt));
+        const delayMilliseconds = getRetryDelay(response.headers.get('retry-after'), attempt);
+        reportRetry(onProgress, source, attempt, delayMilliseconds, error);
+        await wait(delayMilliseconds);
         continue;
       }
       return await response.text();
     } catch (error) {
       if (error instanceof NonRetryableFetchError) throw error;
       lastError = error;
-      if (attempt < MAX_FETCH_ATTEMPTS) await wait(getRetryDelay(null, attempt));
+      if (attempt < MAX_FETCH_ATTEMPTS) {
+        const delayMilliseconds = getRetryDelay(null, attempt);
+        reportRetry(onProgress, source, attempt, delayMilliseconds, error);
+        await wait(delayMilliseconds);
+      }
     } finally {
       clearTimeout(timeout);
     }
@@ -253,6 +299,23 @@ export async function fetchWikipediaPage(
 }
 
 class NonRetryableFetchError extends Error {}
+
+function reportRetry(
+  onProgress: ProgressReporter,
+  source: WikipediaSource,
+  attempt: number,
+  delayMilliseconds: number,
+  error: unknown,
+): void {
+  onProgress({
+    stage: 'retrying',
+    source,
+    attempt: attempt + 1,
+    maxAttempts: MAX_FETCH_ATTEMPTS,
+    delayMilliseconds,
+    reason: error instanceof Error ? error.message : String(error),
+  });
+}
 
 function createRequestPacer(intervalMilliseconds: number): () => Promise<void> {
   let queue = Promise.resolve();

--- a/tests/wikipedia-records.test.ts
+++ b/tests/wikipedia-records.test.ts
@@ -101,6 +101,29 @@ describe('Wikipedia fetching', () => {
     expect(fetcher).toHaveBeenCalledTimes(2);
   });
 
+  it('reports page and retry progress during a data build', async () => {
+    const fetcher = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response('', { status: 429, headers: { 'Retry-After': '0' } }))
+      .mockResolvedValueOnce(new Response(fixture));
+    const progress = vi.fn();
+
+    await buildRecordsData([source], fetcher, progress);
+
+    expect(progress.mock.calls.map(([event]) => event)).toEqual([
+      { stage: 'fetching', source, pageNumber: 1, totalPages: 1 },
+      {
+        stage: 'retrying',
+        source,
+        attempt: 2,
+        maxAttempts: 5,
+        delayMilliseconds: 0,
+        reason: 'Wikipedia returned HTTP 429',
+      },
+      { stage: 'processed', source, pageNumber: 1, totalPages: 1, recordCount: 4 },
+    ]);
+  });
+
   it('fails the data build when a source page cannot be loaded', async () => {
     const fetcher = vi.fn<typeof fetch>().mockResolvedValue(new Response('', { status: 404 }));
 


### PR DESCRIPTION
### Motivation
- Improve observability of the static data build by emitting structured, per-page progress and retry information instead of a single-line progress indicator.

### Description
- Introduced a `BuildProgress` union type and `ProgressReporter` callback and updated `buildRecordsData` and `fetchWikipediaPage` to accept and emit structured `fetching`, `retrying`, and `processed` events.
- Implemented `reportRetry` to surface retry attempts, delay, and failure reasons and wired retries to report before waiting/backoff.
- Added `logProgress` to `scripts/build-data.ts` to log source-list loading, each page fetch with full Wikipedia URL, processed record counts, retry warnings, and final output-writing messages.
- Added a unit test in `tests/wikipedia-records.test.ts` to assert that `fetching`, `retrying`, and `processed` events are emitted with the expected payloads.

### Testing
- Ran `npm test` and all tests passed (15 tests across 2 test files).
- Ran lint and format checks with `biome lint` and `biome format:check` and both succeeded after applying formatting fixes.
- Verified a production build with `npm run build:app` using a temporary `src/data/results.json`, and the TypeScript + Vite build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a76d71744048333a60f8e990fadbf24)