### PR TITLE
Match comparison map colors to the social preview palette

### DIFF
--- a/e2e/comparison.spec.ts
+++ b/e2e/comparison.spec.ts
@@ -69,6 +69,12 @@ test('compares a sprint time using only bundled data', async ({ page }, testInfo
 
   await expect(page.locator('#results')).toBeVisible();
   await expect(page.getByLabel('Event')).not.toBeVisible();
+  await expect(page.locator('.map-country:not(.map-country-faster)').first()).toHaveCSS(
+    'fill',
+    'rgb(48, 50, 56)',
+  );
+  await expect(page.locator('.map-country-faster').first()).toHaveCSS('fill', 'rgb(42, 166, 165)');
+  await expect(page.locator('.map-country-faster').first()).toHaveCSS('stroke', 'rgb(117, 80, 84)');
   const resultsTitle = page.getByRole('heading', { level: 1 });
   await expect(resultsTitle).toContainText(/faster than|does not beat/);
   await expect(resultsTitle).toBeFocused();

--- a/src/styles.css
+++ b/src/styles.css
@@ -14,6 +14,9 @@
   --cream: #fffaf0;
   --coral: #f16b4e;
   --mint: #9dd8c5;
+  --map-land: #303238;
+  --map-highlight: #2aa6a5;
+  --map-border: #755054;
   --line: rgba(21, 34, 56, 0.18);
 }
 
@@ -538,7 +541,7 @@ p {
   width: 100%;
   overflow-x: auto;
   background: var(--landing);
-  scrollbar-color: teal transparent;
+  scrollbar-color: var(--map-highlight) transparent;
 }
 
 #world-map {
@@ -550,8 +553,8 @@ p {
 }
 
 .map-country {
-  fill: teal;
-  stroke: white;
+  fill: var(--map-land);
+  stroke: var(--map-border);
   stroke-width: 0.5;
   transition:
     fill 320ms ease,
@@ -559,8 +562,8 @@ p {
 }
 
 .map-country-faster {
-  fill: #050505;
-  stroke: #ef4444;
+  fill: var(--map-highlight);
+  stroke: var(--map-border);
 }
 
 .country-panel {


### PR DESCRIPTION
### Motivation

- Make the in-app comparison map visually match the social preview image by updating the land, highlight, and border colors and using the same highlight for the horizontal scrollbar.

### Description

- Add three CSS variables `--map-land`, `--map-highlight`, and `--map-border` and use them to restyle the map in `src/styles.css` so unselected countries use a charcoal tone, selected countries use a turquoise highlight, and borders use a muted coral tone.
- Replace the previous `teal`/`white` values with the new variables for `.map-country` and `.map-country-faster` and update the `.map-card` scrollbar color to `--map-highlight`.
- Add end-to-end assertions in `e2e/comparison.spec.ts` to verify the unselected country fill, selected country fill, and selected country stroke colors at run-time.

### Testing

- Ran `npm run lint` (`biome lint`) which passed with no fixes reported.
- Ran `npm test` (`vitest run`) and all tests passed (15 tests across 2 files).
- Ran `npx biome format --check` and fixed formatting for the updated E2E test file, after which `npm run format:check` completed successfully.
- Attempted full `npm run check` and a Playwright screenshot run but these could not complete in the environment because the Git-ignored records snapshot was absent and external Wikipedia fetching and the Playwright browser binary were blocked/unavailable, causing the full check and screenshot capture to fail.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a76f21e69288333b4b7b0ffa22a1534)