### PR TITLE
Highlight map countries and auto-zoom to matched countries

### DIFF
--- a/e2e/comparison.spec.ts
+++ b/e2e/comparison.spec.ts
@@ -74,7 +74,8 @@ test('compares a sprint time using only bundled data', async ({ page }, testInfo
     'rgb(48, 50, 56)',
   );
   await expect(page.locator('.map-country-faster').first()).toHaveCSS('fill', 'rgb(42, 166, 165)');
-  await expect(page.locator('.map-country-faster').first()).toHaveCSS('stroke', 'rgb(117, 80, 84)');
+  await expect(page.locator('.map-country').first()).toHaveCSS('stroke', 'rgb(255, 230, 109)');
+  await expect(page.locator('.map-country-faster').first()).toHaveCSS('stroke-width', '1.25px');
   const resultsTitle = page.getByRole('heading', { level: 1 });
   await expect(resultsTitle).toContainText(/faster than|does not beat/);
   await expect(resultsTitle).toBeFocused();
@@ -121,6 +122,27 @@ test('compares a sprint time using only bundled data', async ({ page }, testInfo
   expect(await page.evaluate(() => window.scrollY)).toBe(0);
   await expect(page.getByRole('spinbutton', { name: 'Seconds' })).toBeVisible();
   expect(consoleErrors).toEqual([]);
+});
+
+test('zooms the map to the countries with slower records', async ({ page }) => {
+  await page.emulateMedia({ reducedMotion: 'reduce' });
+  await page.goto('/');
+  await page.getByLabel('Event').selectOption('1500 metres');
+  await page.getByLabel('Category').selectOption('men');
+
+  const minutes = page.getByRole('spinbutton', { name: 'Minutes' });
+  const seconds = page.getByRole('spinbutton', { name: 'Seconds' });
+  for (let minute = 0; minute < 4; minute += 1) await minutes.press('ArrowDown');
+  for (let second = 0; second < 4; second += 1) await seconds.press('ArrowDown');
+  await page.getByRole('button', { name: 'compare', exact: true }).click();
+
+  await expect(page.locator('.map-country-faster')).toHaveCount(4);
+  await expect(page.locator('#world-map')).not.toHaveAttribute('viewBox', '0 0 1000 500');
+  const viewBox = (await page.locator('#world-map').getAttribute('viewBox')) ?? '0 0 1000 500';
+  const width = Number(viewBox.split(' ')[2]);
+  const height = Number(viewBox.split(' ')[3]);
+  expect(width).toBeLessThan(500);
+  expect(width / height).toBeCloseTo(2, 5);
 });
 
 test('rebuilds the picker when the browser restores native selections', async ({ page }) => {

--- a/src/styles.css
+++ b/src/styles.css
@@ -16,7 +16,7 @@
   --mint: #9dd8c5;
   --map-land: #303238;
   --map-highlight: #2aa6a5;
-  --map-border: #755054;
+  --map-border: #ffe66d;
   --line: rgba(21, 34, 56, 0.18);
 }
 
@@ -555,7 +555,8 @@ p {
 .map-country {
   fill: var(--map-land);
   stroke: var(--map-border);
-  stroke-width: 0.5;
+  stroke-width: 0.75;
+  vector-effect: non-scaling-stroke;
   transition:
     fill 320ms ease,
     stroke 320ms ease;
@@ -564,6 +565,7 @@ p {
 .map-country-faster {
   fill: var(--map-highlight);
   stroke: var(--map-border);
+  stroke-width: 1.25;
 }
 
 .country-panel {

--- a/src/ui/app.ts
+++ b/src/ui/app.ts
@@ -38,6 +38,8 @@ interface AppElements {
 
 const records = recordsJson as unknown as RecordsData;
 const SVG_NAMESPACE = 'http://www.w3.org/2000/svg';
+const WORLD_MAP_VIEW_BOX = { x: 0, y: 0, width: 1000, height: 500 } as const;
+const MAP_ZOOM_DURATION_MS = 900;
 const MAP_NAME_ALIASES: Record<string, string> = {
   'Antigua and Barbuda': 'Antigua and Barb.',
   'Central African Republic': 'Central African Rep.',
@@ -54,6 +56,7 @@ const MAP_NAME_ALIASES: Record<string, string> = {
 export class HowFastApp {
   private readonly elements: AppElements;
   private readonly mapPaths = new Map<string, SVGPathElement>();
+  private mapAnimationFrame = 0;
 
   constructor(private readonly document: Document = globalThis.document) {
     this.elements = this.getElements();
@@ -353,6 +356,7 @@ export class HowFastApp {
     this.highlightCountries(slowerRecords);
     this.elements.results.hidden = false;
     this.document.body.classList.add('showing-results');
+    this.zoomMapToCountries(slowerRecords);
     this.elements.resultsTitle.focus({ preventScroll: true });
     this.document.defaultView?.scrollTo({ top: 0, behavior: this.getScrollBehavior('smooth') });
     this.updateReturnTopButton();
@@ -413,6 +417,73 @@ export class HowFastApp {
       const mapName = MAP_NAME_ALIASES[record.country] ?? record.country;
       this.mapPaths.get(mapName)?.classList.add('map-country-faster');
     }
+  }
+
+  private zoomMapToCountries(slowerRecords: NationalRecord[]): void {
+    if (this.mapAnimationFrame !== 0) cancelAnimationFrame(this.mapAnimationFrame);
+    this.elements.worldMap.setAttribute('viewBox', this.formatViewBox(WORLD_MAP_VIEW_BOX));
+
+    const highlightedPaths = slowerRecords
+      .map((record) => MAP_NAME_ALIASES[record.country] ?? record.country)
+      .map((country) => this.mapPaths.get(country))
+      .filter((path): path is SVGPathElement => path !== undefined);
+    if (highlightedPaths.length === 0) return;
+
+    const boxes = highlightedPaths.map((path) => path.getBBox());
+    const left = Math.min(...boxes.map((box) => box.x));
+    const top = Math.min(...boxes.map((box) => box.y));
+    const right = Math.max(...boxes.map((box) => box.x + box.width));
+    const bottom = Math.max(...boxes.map((box) => box.y + box.height));
+    const target = this.createMapViewBox(left, top, right, bottom);
+
+    if (this.getScrollBehavior('smooth') === 'auto') {
+      this.elements.worldMap.setAttribute('viewBox', this.formatViewBox(target));
+      return;
+    }
+
+    const startedAt = performance.now();
+    const animate = (now: number): void => {
+      const progress = Math.min(1, (now - startedAt) / MAP_ZOOM_DURATION_MS);
+      const easedProgress = 1 - (1 - progress) ** 3;
+      const current = {
+        x: WORLD_MAP_VIEW_BOX.x + (target.x - WORLD_MAP_VIEW_BOX.x) * easedProgress,
+        y: WORLD_MAP_VIEW_BOX.y + (target.y - WORLD_MAP_VIEW_BOX.y) * easedProgress,
+        width: WORLD_MAP_VIEW_BOX.width + (target.width - WORLD_MAP_VIEW_BOX.width) * easedProgress,
+        height:
+          WORLD_MAP_VIEW_BOX.height + (target.height - WORLD_MAP_VIEW_BOX.height) * easedProgress,
+      };
+      this.elements.worldMap.setAttribute('viewBox', this.formatViewBox(current));
+
+      if (progress < 1) this.mapAnimationFrame = requestAnimationFrame(animate);
+      else this.mapAnimationFrame = 0;
+    };
+    this.mapAnimationFrame = requestAnimationFrame(animate);
+  }
+
+  private createMapViewBox(left: number, top: number, right: number, bottom: number) {
+    const contentWidth = Math.max(1, right - left);
+    const contentHeight = Math.max(1, bottom - top);
+    const padding = Math.max(12, Math.max(contentWidth, contentHeight) * 0.18);
+    let width = contentWidth + padding * 2;
+    let height = contentHeight + padding * 2;
+
+    if (width / height < 2) width = height * 2;
+    else height = width / 2;
+
+    width = Math.min(width, WORLD_MAP_VIEW_BOX.width);
+    height = Math.min(height, WORLD_MAP_VIEW_BOX.height);
+    const centreX = (left + right) / 2;
+    const centreY = (top + bottom) / 2;
+    return {
+      x: Math.max(0, Math.min(WORLD_MAP_VIEW_BOX.width - width, centreX - width / 2)),
+      y: Math.max(0, Math.min(WORLD_MAP_VIEW_BOX.height - height, centreY - height / 2)),
+      width,
+      height,
+    };
+  }
+
+  private formatViewBox(box: { x: number; y: number; width: number; height: number }): string {
+    return `${box.x} ${box.y} ${box.width} ${box.height}`;
   }
 
   private editTime(): void {


### PR DESCRIPTION
### Motivation

- Make it easier to see which countries match a user-entered comparison time by improving country outlines and focusing the map on matching countries.
- Reduce visual clutter for small result sets by zooming the world map to a tight, padded bounding box around matching countries while preserving aspect ratio and respecting reduced-motion preferences.

### Description

- Added smooth zoom animation and utilities to compute and set a fitted `viewBox` for the SVG world map, starting from the full map and easing into a padded bounding box around matched countries, with an immediate jump when reduced-motion is requested (`src/ui/app.ts`).
- Reset the map `viewBox` on each comparison and cancel any in-progress animation to ensure predictable behavior (`src/ui/app.ts`).
- Changed the country border styling to a bright, high-contrast outline (`--map-border` set to a yellow), increased stroke widths for normal and highlighted countries, and added `vector-effect: non-scaling-stroke` so outlines remain visible while zooming (`src/styles.css`).
- Updated end-to-end tests to assert the new border color and stroke width and added a test that checks the map zooms to the countries with slower records for the men’s 1500 example (`e2e/comparison.spec.ts`).

### Testing

- Ran lint and formatting checks and they passed (`biome lint`, `biome format --check`).
- Ran the unit test suite with `npm test` (Vitest) and all tests passed (15 tests across 2 files).
- `npm run check` attempted to fetch a generated data snapshot and failed because the repository did not contain the generated `src/data/results.json` and the automated download could not complete in this environment, which also prevented a full `build` from completing. The app changes and tests that don’t rely on the missing snapshot succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7708604d148333acfc0e3dd600a699)